### PR TITLE
[feat] add min decimals setting

### DIFF
--- a/core/sdk/src/CandyShop.ts
+++ b/core/sdk/src/CandyShop.ts
@@ -43,7 +43,9 @@ import { CandyShopBuyParams, CandyShopCancelParams, CandyShopSellParams, CandySh
 const DEFAULT_CURRENCY_SYMBOL = 'SOL';
 const DEFAULT_CURRENCY_DECIMALS = 9;
 const DEFAULT_PRICE_DECIMALS = 3;
+const DEFAULT_PRICE_DECIMALS_MIN = 0;
 const DEFAULT_VOLUME_DECIMALS = 1;
+const DEFAULT_VOLUME_DECIMALS_MIN = 0;
 const DEFAULT_MAINNET_CONNECTION_URL = 'https://ssc-dao.genesysgo.net/';
 let staticNodeWallet: any = null;
 
@@ -86,7 +88,9 @@ export class CandyShop {
       currencySymbol: settings?.currencySymbol ?? DEFAULT_CURRENCY_SYMBOL,
       currencyDecimals: settings?.currencyDecimals ?? DEFAULT_CURRENCY_DECIMALS,
       priceDecimals: settings?.priceDecimals ?? DEFAULT_PRICE_DECIMALS,
+      priceDecimalsMin: settings?.priceDecimalsMin ?? DEFAULT_PRICE_DECIMALS_MIN,
       volumeDecimals: settings?.volumeDecimals ?? DEFAULT_VOLUME_DECIMALS,
+      volumeDecimalsMin: settings?.volumeDecimalsMin ?? DEFAULT_VOLUME_DECIMALS_MIN,
       mainnetConnectionUrl: settings?.mainnetConnectionUrl ?? DEFAULT_MAINNET_CONNECTION_URL,
       connectionConfig: settings?.connectionConfig
     };
@@ -168,9 +172,18 @@ export class CandyShop {
     return this._settings.priceDecimals;
   }
 
+  get priceDecimalsMin(): number {
+    return this._settings.priceDecimalsMin;
+  }
+
   get volumeDecimals(): number {
     return this._settings.volumeDecimals;
   }
+
+  get volumeDecimalsMin(): number {
+    return this._settings.volumeDecimalsMin;
+  }
+
   /**
    * Executes Candy Shop __Buy__ and __ExecuteSale__ actions
    *

--- a/core/sdk/src/CandyShopModel.ts
+++ b/core/sdk/src/CandyShopModel.ts
@@ -16,9 +16,13 @@ export interface CandyShopSettings {
   currencySymbol: string;
   /** Shop transaction currency decimals (default is 9 for SOL) */
   currencyDecimals: number;
-  /** Number of decimals to display for price numbers (default is 3) */
+  /** Number of min decimals to display for price numbers (default is 0) */
+  priceDecimalsMin: number;
+  /** Number of max decimals to display for price numbers (default is 3) */
   priceDecimals: number;
-  /** Number of decimals to display for volume numbers (default is 1) */
+  /** Number of min decimals to display for volume numbers (default is 0) */
+  volumeDecimalsMin: number;
+  /** Number of max decimals to display for volume numbers (default is 1) */
   volumeDecimals: number;
   /** Rpc connection endpoint */
   mainnetConnectionUrl: string;

--- a/core/ui/src/components/BuyModal/BuyModalConfirmed.tsx
+++ b/core/ui/src/components/BuyModal/BuyModalConfirmed.tsx
@@ -32,10 +32,10 @@ const BuyModalConfirmed: React.FC<BuyModalConfirmedProps> = ({
     if (!order?.price) return null;
 
     return (Number(order?.price) / candyShop.baseUnitsPerCurrency).toLocaleString(undefined, {
-      minimumFractionDigits: candyShop.priceDecimals,
+      minimumFractionDigits: candyShop.priceDecimalsMin,
       maximumFractionDigits: candyShop.priceDecimals
     });
-  }, [candyShop.baseUnitsPerCurrency, candyShop.priceDecimals, order?.price]);
+  }, [candyShop.baseUnitsPerCurrency, candyShop.priceDecimalsMin, candyShop.priceDecimals, order?.price]);
 
   const onConfirm = () => {
     onClose();

--- a/core/ui/src/components/BuyModal/BuyModalDetail.tsx
+++ b/core/ui/src/components/BuyModal/BuyModalDetail.tsx
@@ -45,10 +45,10 @@ const BuyModalDetail: React.FC<BuyModalDetailProps> = ({
     if (!order?.price) return null;
 
     return (Number(order.price) / candyShop.baseUnitsPerCurrency).toLocaleString(undefined, {
-      minimumFractionDigits: candyShop.priceDecimals,
+      minimumFractionDigits: candyShop.priceDecimalsMin,
       maximumFractionDigits: candyShop.priceDecimals
     });
-  }, [candyShop.baseUnitsPerCurrency, candyShop.priceDecimals, order?.price]);
+  }, [candyShop.baseUnitsPerCurrency, candyShop.priceDecimalsMin, candyShop.priceDecimals, order?.price]);
 
   return (
     <>

--- a/core/ui/src/components/CancelModal/CancelModalDetail.tsx
+++ b/core/ui/src/components/CancelModal/CancelModalDetail.tsx
@@ -47,10 +47,10 @@ export const CancelModalDetail = ({ candyShop, order, onChangeStep, wallet }: Ca
     if (!order?.price) return null;
 
     return (Number(order?.price) / candyShop.baseUnitsPerCurrency).toLocaleString(undefined, {
-      minimumFractionDigits: candyShop.priceDecimals,
+      minimumFractionDigits: candyShop.priceDecimalsMin,
       maximumFractionDigits: candyShop.priceDecimals
     });
-  }, [candyShop.baseUnitsPerCurrency, candyShop.priceDecimals, order?.price]);
+  }, [candyShop.baseUnitsPerCurrency, candyShop.priceDecimalsMin, candyShop.priceDecimals, order?.price]);
 
   return (
     <div className="candy-cancel-modal">

--- a/core/ui/src/components/Order/index.tsx
+++ b/core/ui/src/components/Order/index.tsx
@@ -26,7 +26,7 @@ export const Order: React.FC<OrderProps> = ({ order, wallet, candyShop, walletCo
     if (!order?.price) return null;
 
     return (Number(order?.price) / candyShop.baseUnitsPerCurrency).toLocaleString(undefined, {
-      minimumFractionDigits: candyShop.priceDecimals,
+      minimumFractionDigits: candyShop.priceDecimalsMin,
       maximumFractionDigits: candyShop.priceDecimals
     });
   }, [candyShop.baseUnitsPerCurrency, candyShop.priceDecimals, order?.price]);

--- a/core/ui/src/public/OrderDetail/index.tsx
+++ b/core/ui/src/public/OrderDetail/index.tsx
@@ -41,10 +41,10 @@ export const OrderDetail: React.FC<OrderDetailProps> = ({
     if (!order?.price) return null;
 
     return (Number(order?.price) / candyShop.baseUnitsPerCurrency).toLocaleString(undefined, {
-      minimumFractionDigits: candyShop.priceDecimals,
+      minimumFractionDigits: candyShop.priceDecimalsMin,
       maximumFractionDigits: candyShop.priceDecimals
     });
-  }, [candyShop.baseUnitsPerCurrency, candyShop.priceDecimals, order?.price]);
+  }, [candyShop.baseUnitsPerCurrency, candyShop.priceDecimalsMin, candyShop.priceDecimals, order?.price]);
 
   const isUserListing = wallet?.publicKey && order && order.walletAddress === wallet.publicKey.toString();
 

--- a/core/ui/src/public/Stat/index.tsx
+++ b/core/ui/src/public/Stat/index.tsx
@@ -16,7 +16,7 @@ export const Stat = ({ candyShop, title, description, style }: StatProps): JSX.E
 
   const floorPrice = stat?.floorPrice
     ? (Number(stat.floorPrice) / candyShop.baseUnitsPerCurrency).toLocaleString(undefined, {
-        minimumFractionDigits: candyShop.priceDecimals,
+        minimumFractionDigits: candyShop.priceDecimalsMin,
         maximumFractionDigits: candyShop.priceDecimals
       })
     : null;
@@ -30,7 +30,7 @@ export const Stat = ({ candyShop, title, description, style }: StatProps): JSX.E
 
   const totalVolume = stat?.totalVolume
     ? (Number(stat.totalVolume) / candyShop.baseUnitsPerCurrency).toLocaleString(undefined, {
-        minimumFractionDigits: candyShop.volumeDecimals,
+        minimumFractionDigits: candyShop.volumeDecimalsMin,
         maximumFractionDigits: candyShop.volumeDecimals
       })
     : 0;


### PR DESCRIPTION
Allow user to set minimumFractionDigits and maximumFractionDigits as separate variables so that a price of 1.000 can be displayed as 1, while a price of 1.003 can be displayed as 1.003. In this case, priceDecimalsMin = 0 and priceDecimals = 3.

Currently, minimumFractionDigits and MaximumFractionDigits are both set to priceDecimals.

Same applies for volumeDecimals.