### PR TITLE
[LIQ-613] Remove withdrawBid after buyNow

### DIFF
--- a/core/sdk/src/api/program/v1/auction/buyNow.ts
+++ b/core/sdk/src/api/program/v1/auction/buyNow.ts
@@ -1,5 +1,5 @@
 import * as anchor from '@project-serum/anchor';
-import { SYSVAR_CLOCK_PUBKEY, Transaction, PublicKey } from '@solana/web3.js';
+import { PublicKey, SYSVAR_CLOCK_PUBKEY, Transaction } from '@solana/web3.js';
 import {
   AUCTION_HOUSE_PROGRAM_ID,
   BuyNowAuctionParams,
@@ -15,9 +15,8 @@ import {
   sendTx,
   treasuryMintIsNative
 } from '../../..';
-import { checkIfBidExists, getBid } from '../../../utils';
+import { getBid } from '../../../utils';
 import { requestExtraComputeIx } from '../../requestExtraComputeIx';
-import { withdrawBid } from './withdraw';
 
 export const buyNowAuction = async ({
   candyShop,
@@ -143,22 +142,6 @@ export const buyNowAuction = async ({
   transaction.add(ix);
   const txId = await sendTx(buyer, transaction, program);
   console.log('Buy Now called with txId ==', txId);
-
-  if (await checkIfBidExists(bid, program.provider.connection)) {
-    console.log("withdrawing user's bid after buy now");
-    await withdrawBid({
-      auction,
-      authority,
-      candyShop,
-      buyer,
-      treasuryMint,
-      nftMint,
-      metadata,
-      auctionHouse,
-      feeAccount,
-      program
-    });
-  }
 
   return txId;
 };

--- a/core/sdk/src/api/program/v2/auction/buyNow.ts
+++ b/core/sdk/src/api/program/v2/auction/buyNow.ts
@@ -1,5 +1,5 @@
 import * as anchor from '@project-serum/anchor';
-import { SYSVAR_CLOCK_PUBKEY, Transaction, PublicKey } from '@solana/web3.js';
+import { PublicKey, SYSVAR_CLOCK_PUBKEY, Transaction } from '@solana/web3.js';
 import {
   AUCTION_HOUSE_PROGRAM_ID,
   BuyNowAuctionParams,
@@ -15,9 +15,8 @@ import {
   sendTx,
   treasuryMintIsNative
 } from '../../..';
-import { checkIfBidExists, getBid } from '../../../utils';
+import { getBid } from '../../../utils';
 import { requestExtraComputeIx } from '../../requestExtraComputeIx';
-import { withdrawBid } from './withdraw';
 
 export const buyNowAuction = async ({
   candyShop,
@@ -143,22 +142,6 @@ export const buyNowAuction = async ({
   transaction.add(ix);
   const txId = await sendTx(buyer, transaction, program);
   console.log('Buy Now called with txId ==', txId);
-
-  if (await checkIfBidExists(bid, program.provider.connection)) {
-    console.log("withdrawing user's bid after buy now");
-    await withdrawBid({
-      auction,
-      authority,
-      candyShop,
-      buyer,
-      treasuryMint,
-      nftMint,
-      metadata,
-      auctionHouse,
-      feeAccount,
-      program
-    });
-  }
 
   return txId;
 };


### PR DESCRIPTION
Due to the state change propagation delay, there
are situations where higgest bidder fails to
withdrawBid after buyNow. Remove the logic for now
and highest bidder will need to go back and withdrawBid
after buyNow. Will need to come up with better UI
solution to it.