### PR TITLE
[fix] create auction styling

### DIFF
--- a/core/ui/src/public/Auction/create-auction-style.less
+++ b/core/ui/src/public/Auction/create-auction-style.less
@@ -15,6 +15,7 @@
     font-weight: 600;
     font-size: 16px;
     padding-bottom: 20px;
+    text-align: center;
   }
 
   .candy-auction-content {


### PR DESCRIPTION
Centralized the text below
<img width="1163" alt="Screen Shot 2022-06-14 at 6 18 01 PM" src="https://user-images.githubusercontent.com/89616076/173554568-7046bdc4-7246-46c2-903c-525b7c33511f.png">
