### PR TITLE
Fine tune compute budget request

### DIFF
--- a/core/sdk/src/factory/program/v1/auction/bid.ts
+++ b/core/sdk/src/factory/program/v1/auction/bid.ts
@@ -12,6 +12,7 @@ import {
 } from '../../../../vendor';
 import { checkAHFeeAccountBalance, checkBidParams } from '../../../../vendor/utils/validationUtils';
 import { BidAuctionParams } from '../../model';
+import { requestExtraComputeIx } from './requestExtraComputeIx';
 
 export const bidAuction = async (params: BidAuctionParams) => {
   const {
@@ -53,6 +54,8 @@ export const bidAuction = async (params: BidAuctionParams) => {
   ]);
 
   const transaction = new Transaction();
+
+  transaction.add(requestExtraComputeIx(1_400_000));
 
   const ix = await program.methods
     .makeBid(bidPrice, bidWalletBump, bidTradeStateBump, escrowPaymentAccountBump)

--- a/core/sdk/src/factory/program/v1/auction/buyNow.ts
+++ b/core/sdk/src/factory/program/v1/auction/buyNow.ts
@@ -95,11 +95,9 @@ export const buyNowAuction = async ({
     isNative
   );
 
-  const [bid] = await getBid(auction, buyer.publicKey, program.programId);
-
   const transaction = new Transaction();
 
-  transaction.add(requestExtraComputeIx(400000));
+  transaction.add(requestExtraComputeIx(1_400_000));
 
   const ix = await program.methods
     .buyNow(

--- a/core/sdk/src/factory/program/v1/auction/settleAndDistribute.ts
+++ b/core/sdk/src/factory/program/v1/auction/settleAndDistribute.ts
@@ -130,7 +130,7 @@ export const settleAndDistributeProceeds = async ({
 
   let transaction = new Transaction();
 
-  transaction.add(requestExtraComputeIx(400000));
+  transaction.add(requestExtraComputeIx(1_400_000));
 
   transaction.add(ix1);
   const tx1 = await sendTx(settler, transaction, program);

--- a/core/sdk/src/factory/program/v2/auction/bid.ts
+++ b/core/sdk/src/factory/program/v2/auction/bid.ts
@@ -13,6 +13,7 @@ import {
   checkBidParams
 } from '../../../../vendor';
 import { BidAuctionParams } from '../../model';
+import { requestExtraComputeIx } from './requestExtraComputeIx';
 
 export const bidAuction = async (params: BidAuctionParams) => {
   const {
@@ -54,6 +55,8 @@ export const bidAuction = async (params: BidAuctionParams) => {
   ]);
 
   const transaction = new Transaction();
+
+  transaction.add(requestExtraComputeIx(1_400_000));
 
   const ix = await program.methods
     .makeBid(bidPrice, bidWalletBump, bidTradeStateBump, escrowPaymentAccountBump)

--- a/core/sdk/src/factory/program/v2/auction/buyNow.ts
+++ b/core/sdk/src/factory/program/v2/auction/buyNow.ts
@@ -97,7 +97,7 @@ export const buyNowAuction = async ({
 
   const transaction = new Transaction();
 
-  transaction.add(requestExtraComputeIx(400000));
+  transaction.add(requestExtraComputeIx(1_400_000));
 
   const ix = await program.methods
     .buyNow(

--- a/core/sdk/src/factory/program/v2/auction/settleAndDistribute.ts
+++ b/core/sdk/src/factory/program/v2/auction/settleAndDistribute.ts
@@ -130,7 +130,7 @@ export const settleAndDistributeProceeds = async ({
 
   let transaction = new Transaction();
 
-  transaction.add(requestExtraComputeIx(400000));
+  transaction.add(requestExtraComputeIx(1_400_000));
 
   transaction.add(ix1);
   const tx1 = await sendTx(settler, transaction, program);


### PR DESCRIPTION
Compute units required varies depends on number of creators
in the NFT to be settled. This patch simply set the compute unit
close to max to avoid insufficient compute unit error.