### PR TITLE
[feat] styling tweaks for search and sidebar

### DIFF
--- a/core/ui/src/components/CollectionFilter/index.tsx
+++ b/core/ui/src/components/CollectionFilter/index.tsx
@@ -16,6 +16,7 @@ interface CollectionFilterProps {
   selectedManual?: CollectionFilterType;
   shopId?: string;
   showAllFilters: boolean;
+  search?: boolean;
 }
 
 const Logger = 'CandyShopUI/Collection';
@@ -28,7 +29,8 @@ export const CollectionFilter: React.FC<CollectionFilterProps> = ({
   filters,
   selectedManual,
   shopId,
-  showAllFilters
+  showAllFilters,
+  search
 }) => {
   const [options, setOptions] = useState<NftCollection[]>([]);
   const [offset, setOffset] = useState<number>(0);
@@ -107,9 +109,9 @@ export const CollectionFilter: React.FC<CollectionFilterProps> = ({
   if (Array.isArray(filters)) {
     return (
       <>
-        <div className="candy-filter-title">By Collection</div>
+        <div className="candy-filter-subtitle">Collections</div>
         <ul>
-          <Search onSearch={onSearch} placeholder="Search collections" />
+          {search && <Search onSearch={onSearch} placeholder="Search collections" />}
           {selectedManual ? (
             <div className="candy-filter-selected-name">
               {selectedManual.name}
@@ -141,8 +143,8 @@ export const CollectionFilter: React.FC<CollectionFilterProps> = ({
 
   return (
     <div className="candy-collection-filter">
-      <div className="candy-filter-title">By Collection</div>
-      <Search onSearch={onSearch} placeholder="Search collections" />
+      <div className="candy-filter-subtitle">Collections</div>
+      {search && <Search onSearch={onSearch} placeholder="Search collections" />}
       {selected ? (
         <div className="candy-filter-selected-name">
           {selected.name}

--- a/core/ui/src/components/Search/style.less
+++ b/core/ui/src/components/Search/style.less
@@ -6,9 +6,10 @@
 
   input {
     padding: 4px 4px 4px 24px;
-    border-radius: 8px;
+    border-radius: 4px;
     outline: none;
-    border: 2px solid @gray-medium-alt;
+    border: 1px solid @gray-medium-alt;
+    width: 100%;
 
     &::placeholder {
       color: @gray-medium-alt;

--- a/core/ui/src/components/ShopFilter/index.tsx
+++ b/core/ui/src/components/ShopFilter/index.tsx
@@ -16,6 +16,7 @@ interface ShopFilterProps {
   filters?: ShopFilterInfo[] | boolean;
   selectedManual?: ShopFilterInfo;
   showAllFilters: boolean;
+  search?: boolean;
 }
 
 const Logger = 'CandyShopUI/ShopFilter';
@@ -27,7 +28,8 @@ export const ShopFilter: React.FC<ShopFilterProps> = ({
   candyShop,
   filters,
   selectedManual,
-  showAllFilters
+  showAllFilters,
+  search
 }) => {
   const [options, setOptions] = useState<CandyShopResponse[]>([]);
   const [offset, setOffset] = useState<number>(0);
@@ -92,8 +94,8 @@ export const ShopFilter: React.FC<ShopFilterProps> = ({
   if (Array.isArray(filters)) {
     return (
       <>
-        <div className="candy-filter-title">By Shop</div>
-        <Search onSearch={onSearch} placeholder="Search shops" />
+        <div className="candy-filter-subtitle">Shops</div>
+        {search && <Search onSearch={onSearch} placeholder="Search shops" />}
         {selected ? (
           <div className="candy-filter-selected-name">
             {selected.candyShopName}
@@ -124,8 +126,8 @@ export const ShopFilter: React.FC<ShopFilterProps> = ({
 
   return (
     <div className="candy-collection-filter">
-      <div className="candy-filter-title">By Shop</div>
-      <Search onSearch={onSearch} placeholder="Search shops" />
+      <div className="candy-filter-subtitle">Shops</div>
+      {search && <Search onSearch={onSearch} placeholder="Search shops" />}
       {selected ? (
         <div className="candy-filter-selected-name">
           {selected.candyShopName}

--- a/core/ui/src/components/Tooltip/style.less
+++ b/core/ui/src/components/Tooltip/style.less
@@ -35,6 +35,7 @@
     max-width: 300px;
     visibility: hidden;
     font-size: 14px;
+    line-height: 20px;
   }
 
   &-label {

--- a/core/ui/src/public/Orders/index.less
+++ b/core/ui/src/public/Orders/index.less
@@ -44,16 +44,14 @@
     flex-flow: row wrap;
 
     .candy-filter-all {
-      padding: 8px 0 8px 8px;
-      border-radius: 4px;
-      margin-bottom: 20px;
+      padding: 4px 8px;
+      margin-bottom: 15px;
       cursor: pointer;
 
       &.candy-filter-all-active {
         font-weight: bold;
         color: @primary-color;
         background-color: #f4edfe;
-        padding: 8px;
       }
     }
 
@@ -67,12 +65,7 @@
         li {
           cursor: pointer;
           transition: 0.2s all ease-in-out;
-          padding: 8px 0 8px 8px;
-          border-radius: 4px;
-
-          &:hover {
-            background-color: #f4edfe;
-          }
+          padding: 4px 8px;
         }
 
         li.selected {
@@ -85,8 +78,17 @@
       .candy-filter-title {
         font-weight: bold;
         font-size: 16px;
+        line-height: 20px;
+        padding-bottom: 12px;
+        border-bottom: 1px solid @gray-medium-alt;
+        margin-bottom: 15px;
+      }
+
+      .candy-filter-subtitle {
+        font-weight: bold;
+        font-size: 16px;
         line-height: 26px;
-        margin-bottom: 5px;
+        margin-bottom: 8px;
       }
 
       .candy-filter-attribute {

--- a/core/ui/src/public/Orders/index.tsx
+++ b/core/ui/src/public/Orders/index.tsx
@@ -40,6 +40,8 @@ interface OrdersProps {
   candyShop: CandyShop;
   sellerAddress?: string;
   sellerUrl?: string;
+  search?: boolean;
+  filterSearch?: boolean;
 }
 
 /**
@@ -56,7 +58,9 @@ export const Orders: React.FC<OrdersProps> = ({
   sellerAddress,
   shopFilters,
   defaultFilter,
-  sellerUrl
+  sellerUrl,
+  search,
+  filterSearch
 }) => {
   const [sortedByOption, setSortedByOption] = useState(SORT_OPTIONS[0]);
   const [orders, setOrders] = useState<any[]>([]);
@@ -219,7 +223,7 @@ export const Orders: React.FC<OrdersProps> = ({
       <div className="candy-orders-container" style={style}>
         <div className="candy-container">
           <div className="candy-orders-sort candy-orders-sort-right">
-            <Search onSearch={onSearchNft} placeholder="Search NFT name" />
+            {search && <Search onSearch={onSearchNft} placeholder="Search NFTs" />}
             <Dropdown
               items={SORT_OPTIONS}
               selectedItem={sortedByOption}
@@ -251,6 +255,7 @@ export const Orders: React.FC<OrdersProps> = ({
                   selectedManual={collectionFilter}
                   shopId={selectedShop?.candyShopAddress || shopFilter?.shopId}
                   showAllFilters={showAll}
+                  search={filterSearch}
                 />
               )}
               {Boolean(shopFilters) === true && (
@@ -261,6 +266,7 @@ export const Orders: React.FC<OrdersProps> = ({
                   filters={shopFilters}
                   selectedManual={shopFilter}
                   showAllFilters={showAll}
+                  search={filterSearch}
                 />
               )}
 
@@ -296,7 +302,7 @@ export const Orders: React.FC<OrdersProps> = ({
               onSelectItem={(item) => setSortedByOption(item)}
               defaultValue={SORT_OPTIONS[0]}
             />
-            <Search onSearch={onSearchNft} placeholder="Search NFT name" />
+            <Search onSearch={onSearchNft} placeholder="Search NFTs" />
           </div>
           {loading ? <LoadingSkeleton /> : orders.length ? infiniteOrderListView : emptyView}
           <PoweredBy />

--- a/core/ui/src/style/order-filter.less
+++ b/core/ui/src/style/order-filter.less
@@ -8,7 +8,7 @@
   border: 1px solid @primary-color;
   border-radius: 4px;
   width: fit-content;
-  margin-bottom: 4px;
+  margin-bottom: 6px;
 
   span.close-icon {
     margin-left: 4px;
@@ -42,7 +42,7 @@
     border: none;
     outline: none;
     background: transparent;
-    margin-top: 16px;
+    padding: 4px 8px;
 
     &-disable {
       color: @gray-medium-alt;

--- a/example/MarketplaceExample.tsx
+++ b/example/MarketplaceExample.tsx
@@ -32,12 +32,13 @@ export const MarketplaceExample: React.FC<MarketplaceExampleProps> = ({ candySho
         walletConnectComponent={<WalletMultiButton />}
         candyShop={candyShop}
         filters={FILTERS}
-        shopFilters
+        filterSearch
+        search
       />
 
       <h1 style={{ textAlign: 'center', fontWeight: 'bold', marginBottom: 30 }}>Order Detail</h1>
       <OrderDetail
-        tokenMint={'5vGqYy1Vqg5a338gSMtBjh8qUumACWZAUVALD9KrHWDi'}
+        tokenMint={'Aj1k5FNSCkagdtEwjYzpKV47SGokioyCCy2XtqZ9t38G'}
         backUrl={'/'}
         walletConnectComponent={<WalletMultiButton />}
         wallet={wallet}


### PR DESCRIPTION
- User can specify `search` and `filterSearch` argument to Orders component to show/hide search and filterSearch
- In example, show only collection filter (as most users do not use shop filter)
- Refine styling for search NFT box and filter bar

<img width="1256" alt="Screen Shot 2022-07-16 at 3 21 21 PM" src="https://user-images.githubusercontent.com/89616076/179344798-4a368601-6004-4c0e-b800-98642bb97336.png">
