### PR TITLE
Update ATA programId to redeemDrop

### DIFF
--- a/core/cli/src/cli.ts
+++ b/core/cli/src/cli.ts
@@ -619,11 +619,21 @@ programCommand('mintPrint')
 programCommand('redeemDrop')
   .description('mint an edition-ed NFT from the master edition')
   .requiredOption('-ota, --nft-owner-token-account <string>', 'NFT token account address')
+  .requiredOption('-mem, --master-edition-mint <string>', 'NFT master edition mint address')
   .requiredOption('-tm, --treasury-mint <string>', 'Candy Shop treasury mint')
   .requiredOption('-sc, --shop-creator <string>', 'Candy Shop creator address')
   .action(async (name, cmd) => {
-    let { keypair, env, nftOwnerTokenAccount, treasuryMint, rpcUrl, shopCreator, version, isEnterpriseArg } =
-      cmd.opts();
+    let {
+      keypair,
+      env,
+      nftOwnerTokenAccount,
+      masterEditionMint,
+      treasuryMint,
+      rpcUrl,
+      shopCreator,
+      version,
+      isEnterpriseArg
+    } = cmd.opts();
     const wallet = loadKey(keypair);
 
     if (version !== 'v2') {
@@ -644,12 +654,10 @@ programCommand('redeemDrop')
       isEnterprise: isEnterprise(isEnterpriseArg)
     });
 
-    const tokenAccountInfo = await getAccount(candyShop.connection(), new PublicKey(nftOwnerTokenAccount), 'finalized');
-
     const txHash = await candyShop.redeemDrop({
       nftOwner: wallet,
       nftOwnerTokenAccount: new PublicKey(nftOwnerTokenAccount),
-      masterMint: tokenAccountInfo.mint
+      masterMint: new PublicKey(masterEditionMint)
     });
 
     console.log('txHash', txHash);

--- a/core/sdk/src/factory/program/v2/editionDrop/redeemNft.ts
+++ b/core/sdk/src/factory/program/v2/editionDrop/redeemNft.ts
@@ -1,4 +1,4 @@
-import { TOKEN_PROGRAM_ID } from '@solana/spl-token';
+import { ASSOCIATED_TOKEN_PROGRAM_ID, TOKEN_PROGRAM_ID } from '@solana/spl-token';
 import { SystemProgram, SYSVAR_RENT_PUBKEY, Transaction } from '@solana/web3.js';
 import { checkRedeemable, getAtaForMint, sendTx } from '../../../../vendor';
 import { RedeemNftParams } from '../../model';
@@ -22,6 +22,7 @@ export const redeemNft = async (params: RedeemNftParams) => {
       nftMint: masterMint,
       systemProgram: SystemProgram.programId,
       tokenProgram: TOKEN_PROGRAM_ID,
+      associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
       rent: SYSVAR_RENT_PUBKEY
     })
     .instruction();

--- a/core/sdk/src/idl/edition_drop.json
+++ b/core/sdk/src/idl/edition_drop.json
@@ -6,64 +6,59 @@
       "name": "shopCommitNft",
       "accounts": [
         {
-          "name": "commitNftCtx",
-          "accounts": [
-            {
-              "name": "masterEditionTokenAccountAuthority",
-              "isMut": true,
-              "isSigner": true
-            },
-            {
-              "name": "masterEditionTokenAccount",
-              "isMut": true,
-              "isSigner": false
-            },
-            {
-              "name": "vaultAccount",
-              "isMut": true,
-              "isSigner": false
-            },
-            {
-              "name": "vaultTokenAccount",
-              "isMut": true,
-              "isSigner": false
-            },
-            {
-              "name": "masterEditionMetadata",
-              "isMut": false,
-              "isSigner": false
-            },
-            {
-              "name": "masterEditionAccount",
-              "isMut": false,
-              "isSigner": false
-            },
-            {
-              "name": "masterEditionMint",
-              "isMut": false,
-              "isSigner": false
-            },
-            {
-              "name": "systemProgram",
-              "isMut": false,
-              "isSigner": false
-            },
-            {
-              "name": "tokenProgram",
-              "isMut": false,
-              "isSigner": false
-            },
-            {
-              "name": "associatedTokenProgram",
-              "isMut": false,
-              "isSigner": false
-            },
-            {
-              "name": "rent",
-              "isMut": false,
-              "isSigner": false
-            }
-          ]
+          "name": "masterEditionTokenAccountAuthority",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "masterEditionTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "vaultAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "vaultTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "masterEditionMetadata",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "masterEditionAccount",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "masterEditionMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "associatedTokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
         },
         {
           "name": "candyShop",
@@ -96,64 +91,59 @@
       "name": "enterpriseCommitNft",
       "accounts": [
         {
-          "name": "commitNftCtx",
-          "accounts": [
-            {
-              "name": "masterEditionTokenAccountAuthority",
-              "isMut": true,
-              "isSigner": true
-            },
-            {
-              "name": "masterEditionTokenAccount",
-              "isMut": true,
-              "isSigner": false
-            },
-            {
-              "name": "vaultAccount",
-              "isMut": true,
-              "isSigner": false
-            },
-            {
-              "name": "vaultTokenAccount",
-              "isMut": true,
-              "isSigner": false
-            },
-            {
-              "name": "masterEditionMetadata",
-              "isMut": false,
-              "isSigner": false
-            },
-            {
-              "name": "masterEditionAccount",
-              "isMut": false,
-              "isSigner": false
-            },
-            {
-              "name": "masterEditionMint",
-              "isMut": false,
-              "isSigner": false
-            },
-            {
-              "name": "systemProgram",
-              "isMut": false,
-              "isSigner": false
-            },
-            {
-              "name": "tokenProgram",
-              "isMut": false,
-              "isSigner": false
-            },
-            {
-              "name": "associatedTokenProgram",
-              "isMut": false,
-              "isSigner": false
-            },
-            {
-              "name": "rent",
-              "isMut": false,
-              "isSigner": false
-            }
-          ]
+          "name": "masterEditionTokenAccountAuthority",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "masterEditionTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "vaultAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "vaultTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "masterEditionMetadata",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "masterEditionAccount",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "masterEditionMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "associatedTokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
         },
         {
           "name": "candyShop",
@@ -186,99 +176,94 @@
       "name": "shopMintPrint",
       "accounts": [
         {
-          "name": "mintPrintCtx",
-          "accounts": [
-            {
-              "name": "newEditionBuyer",
-              "isMut": true,
-              "isSigner": true
-            },
-            {
-              "name": "vaultAccount",
-              "isMut": true,
-              "isSigner": false
-            },
-            {
-              "name": "vaultTokenAccount",
-              "isMut": true,
-              "isSigner": false
-            },
-            {
-              "name": "masterEditionMetadata",
-              "isMut": false,
-              "isSigner": false
-            },
-            {
-              "name": "masterEditionUpdateAuthority",
-              "isMut": false,
-              "isSigner": false
-            },
-            {
-              "name": "masterEditionAccount",
-              "isMut": true,
-              "isSigner": false
-            },
-            {
-              "name": "masterEditionMint",
-              "isMut": false,
-              "isSigner": false
-            },
-            {
-              "name": "masterEditionTokenAccount",
-              "isMut": true,
-              "isSigner": false
-            },
-            {
-              "name": "newEditionMetadata",
-              "isMut": true,
-              "isSigner": false
-            },
-            {
-              "name": "newEditionAccount",
-              "isMut": true,
-              "isSigner": false
-            },
-            {
-              "name": "newEditionMarker",
-              "isMut": true,
-              "isSigner": false
-            },
-            {
-              "name": "newEditionMint",
-              "isMut": true,
-              "isSigner": false
-            },
-            {
-              "name": "newEditionTokenAccount",
-              "isMut": true,
-              "isSigner": false
-            },
-            {
-              "name": "shopTreasuryAddress",
-              "isMut": true,
-              "isSigner": false
-            },
-            {
-              "name": "tokenMetadataProgram",
-              "isMut": false,
-              "isSigner": false
-            },
-            {
-              "name": "systemProgram",
-              "isMut": false,
-              "isSigner": false
-            },
-            {
-              "name": "tokenProgram",
-              "isMut": false,
-              "isSigner": false
-            },
-            {
-              "name": "rent",
-              "isMut": false,
-              "isSigner": false
-            }
-          ]
+          "name": "newEditionBuyer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "vaultAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "vaultTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "masterEditionMetadata",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "masterEditionUpdateAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "masterEditionAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "masterEditionMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "masterEditionTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "newEditionMetadata",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "newEditionAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "newEditionMarker",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "newEditionMint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "newEditionTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "shopTreasuryAddress",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenMetadataProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
         },
         {
           "name": "candyShop",
@@ -297,99 +282,94 @@
       "name": "enterpriseMintPrint",
       "accounts": [
         {
-          "name": "mintPrintCtx",
-          "accounts": [
-            {
-              "name": "newEditionBuyer",
-              "isMut": true,
-              "isSigner": true
-            },
-            {
-              "name": "vaultAccount",
-              "isMut": true,
-              "isSigner": false
-            },
-            {
-              "name": "vaultTokenAccount",
-              "isMut": true,
-              "isSigner": false
-            },
-            {
-              "name": "masterEditionMetadata",
-              "isMut": false,
-              "isSigner": false
-            },
-            {
-              "name": "masterEditionUpdateAuthority",
-              "isMut": false,
-              "isSigner": false
-            },
-            {
-              "name": "masterEditionAccount",
-              "isMut": true,
-              "isSigner": false
-            },
-            {
-              "name": "masterEditionMint",
-              "isMut": false,
-              "isSigner": false
-            },
-            {
-              "name": "masterEditionTokenAccount",
-              "isMut": true,
-              "isSigner": false
-            },
-            {
-              "name": "newEditionMetadata",
-              "isMut": true,
-              "isSigner": false
-            },
-            {
-              "name": "newEditionAccount",
-              "isMut": true,
-              "isSigner": false
-            },
-            {
-              "name": "newEditionMarker",
-              "isMut": true,
-              "isSigner": false
-            },
-            {
-              "name": "newEditionMint",
-              "isMut": true,
-              "isSigner": false
-            },
-            {
-              "name": "newEditionTokenAccount",
-              "isMut": true,
-              "isSigner": false
-            },
-            {
-              "name": "shopTreasuryAddress",
-              "isMut": true,
-              "isSigner": false
-            },
-            {
-              "name": "tokenMetadataProgram",
-              "isMut": false,
-              "isSigner": false
-            },
-            {
-              "name": "systemProgram",
-              "isMut": false,
-              "isSigner": false
-            },
-            {
-              "name": "tokenProgram",
-              "isMut": false,
-              "isSigner": false
-            },
-            {
-              "name": "rent",
-              "isMut": false,
-              "isSigner": false
-            }
-          ]
+          "name": "newEditionBuyer",
+          "isMut": true,
+          "isSigner": true
+        },
+        {
+          "name": "vaultAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "vaultTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "masterEditionMetadata",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "masterEditionUpdateAuthority",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "masterEditionAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "masterEditionMint",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "masterEditionTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "newEditionMetadata",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "newEditionAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "newEditionMarker",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "newEditionMint",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "newEditionTokenAccount",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "shopTreasuryAddress",
+          "isMut": true,
+          "isSigner": false
+        },
+        {
+          "name": "tokenMetadataProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "systemProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "rent",
+          "isMut": false,
+          "isSigner": false
         },
         {
           "name": "candyShop",
@@ -439,6 +419,11 @@
         },
         {
           "name": "tokenProgram",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "associatedTokenProgram",
           "isMut": false,
           "isSigner": false
         },


### PR DESCRIPTION
There are situations where after users commit a master edition NFT, they will close the token account. A change is added in the onchain program to make sure the check will be conducted against the mint account address directly instead of relying on the mint address in the token account. This change adds an extra ATA program argument into the redeemNft rpc handler, so the committer's master edition NFT token account can be re-initialized upon redemption.

