### PR TITLE
Add OrderStatus for EVM chains

### DIFF
--- a/core/types/src/response/order.ts
+++ b/core/types/src/response/order.ts
@@ -9,7 +9,9 @@ export enum Status {
   OPEN,
   FILLED,
   UNEXECUTABLE,
-  CANCELLED
+  CANCELLED,
+  PENDING_FILLED,
+  PENDING_CANCELLED
 }
 
 export interface Order {


### PR DESCRIPTION
Since chain reorg is a possibility in the EVM chains, introducing pending states for `filled` and `cancelled`. The state will transition into finalized once required number of confirmations is reached.