### PR TITLE
[UI] Update-auction-activity-union-types

### DIFF
--- a/core/ui/src/public/AuctionActivity/index.tsx
+++ b/core/ui/src/public/AuctionActivity/index.tsx
@@ -4,17 +4,29 @@ import { ExplorerLink } from 'components/ExplorerLink';
 import { Processing } from 'components/Processing';
 import InfiniteScroll from 'react-infinite-scroll-component';
 
-import { CandyShop, fetchAuctionHistory } from '@liqnft/candy-shop-sdk';
+import { CandyShop, fetchAuctionHistory, ExplorerLinkBase } from '@liqnft/candy-shop-sdk';
 import { AuctionBid, AuctionStatus, ListBase, SortBy } from '@liqnft/candy-shop-types';
 import { removeDuplicate, EMPTY_FUNCTION } from 'utils/helperFunc';
 
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
+
+import { web3 } from '@project-serum/anchor';
+
 dayjs.extend(relativeTime);
 import './style.less';
 
+interface ShopInfo {
+  env: web3.Cluster;
+  explorerLink: ExplorerLinkBase;
+  baseUnitsPerCurrency: number;
+  priceDecimalsMin: number;
+  priceDecimals: number;
+  currencySymbol: string;
+}
+
 interface AuctionActivityProps {
-  candyShop: CandyShop;
+  candyShop: CandyShop | ShopInfo;
   orderBy?: SortBy;
   auctionAddress: string;
 }

--- a/example/AuctionExample.tsx
+++ b/example/AuctionExample.tsx
@@ -45,6 +45,19 @@ export const AuctionExample: React.FC<AuctionExampleProps> = ({ candyShop }) => 
         auctionAddress="91cr87Pib1ue3obYrZnDmzsa4KAok6UvRFi2F2c6LxQa"
         orderBy={AUCTION_ORDER}
       />
+      {/* Can serve AuctionActivity with partial shop info without CandyShop instance to present the same */}
+      {/* <AuctionActivity
+        candyShop={{
+          env: candyShop.env,
+          explorerLink: candyShop.explorerLink,
+          baseUnitsPerCurrency: candyShop.baseUnitsPerCurrency,
+          priceDecimalsMin: candyShop.priceDecimalsMin,
+          priceDecimals: candyShop.priceDecimals,
+          currencySymbol: candyShop.currencySymbol,
+        }}
+        auctionAddress="91cr87Pib1ue3obYrZnDmzsa4KAok6UvRFi2F2c6LxQa"
+        orderBy={AUCTION_ORDER}
+      /> */}
     </div>
   );
 };


### PR DESCRIPTION
Currently, the main UI components: AuctionActivity in public need candyShop: CandyShop as prop but the methods they called from sdk now can use without the CandyShop instance but just currencySymbol or partial infos.

To avoid breaking backward compatibility, I use union-types that can serve AuctionActivity with partial shop info without CandyShop instance.