### PR TITLE
[sdk] Update default mainnet rpc url

### DIFF
--- a/core/sdk/src/CandyShop.ts
+++ b/core/sdk/src/CandyShop.ts
@@ -95,7 +95,7 @@ const DEFAULT_PRICE_DECIMALS = 3;
 const DEFAULT_PRICE_DECIMALS_MIN = 0;
 const DEFAULT_VOLUME_DECIMALS = 1;
 const DEFAULT_VOLUME_DECIMALS_MIN = 0;
-const DEFAULT_MAINNET_CONNECTION_URL = 'https://ssc-dao.genesysgo.net/';
+const DEFAULT_MAINNET_CONNECTION_URL = 'https://api.mainnet-beta.solana.com';
 
 /**
  * @class CandyShop

--- a/example/constant/formConfiguration.ts
+++ b/example/constant/formConfiguration.ts
@@ -10,7 +10,7 @@ export const DEFAULT_FORM_CONFIG = {
   network: WalletAdapterNetwork.Devnet,
   settings: JSON.stringify(
     {
-      mainnetConnectionUrl: 'https://ssc-dao.genesysgo.net/',
+      mainnetConnectionUrl: 'https://api.mainnet-beta.solana.com',
       currencySymbol: 'SOL',
       currencyDecimals: 9
     },


### PR DESCRIPTION
Due to the decommission of the Genesysgo free rpc, switching the default mainnet rpc back to the foundation rpc.

ref: https://twitter.com/GenesysGo/status/1583508696487067653?s=20&t=Zgy9izUpKzSvSjHA4orwWw