### PR TITLE
[sdk][ui] Enhance UNPREDICTABLE_GAS_LIMIT handling

### DIFF
--- a/core/ui/src/components/BuyModal/index.tsx
+++ b/core/ui/src/components/BuyModal/index.tsx
@@ -77,7 +77,7 @@ export const BuyModal: React.FC<BuyModalProps> = ({
       })
       .catch((err: Error) => {
         console.log(`${Logger} buyNft failed, error=`, err);
-        err.message = (err as any).code || err.message;
+        err.message = (err as any).error?.data?.message || (err as any).code || err.message;
         handleError({ error: err });
         setState(BuyModalState.DISPLAY);
       });


### PR DESCRIPTION
According to https://docs.ethers.io/v5/troubleshooting/errors/#help-UNPREDICTABLE_GAS_LIMIT, there are 2 cases where the library will return `UNPREDICTABLE_GAS_LIMIT` error.

1. tx itself is destined to fail
2. tx is too complex to do gas estimation.

This change handles the case 2 by defaulting the gasLimit to a predefined level and let case 1 be processed as an error and propagate to the UI layer, with more verbose error message displayed, if available. 

LIQ-911