### PR TITLE
[sdk] update fetchOrders blockchain in SOL

### DIFF
--- a/core/sdk/src/factory/backend/OrderAPI.ts
+++ b/core/sdk/src/factory/backend/OrderAPI.ts
@@ -11,8 +11,6 @@ import {
 import { AxiosInstance } from 'axios';
 import qs from 'qs';
 
-const DEFAULT_BLOCKCHAIN = Blockchain.Sol;
-
 export async function fetchOrdersByStoreId(
   axiosInstance: AxiosInstance,
   storeId: string,
@@ -29,9 +27,17 @@ export async function fetchOrdersByStoreId(
     collectionId,
     nftName,
     masterEdition,
-    collectionKey,
-    blockchain = DEFAULT_BLOCKCHAIN
+    collectionKey
   } = ordersFilterQuery;
+
+  let blockchain = ordersFilterQuery.blockchain;
+  if (
+    ordersFilterQuery.blockchain === Blockchain.SolDevnet ||
+    ordersFilterQuery.blockchain === Blockchain.SolMainnetBeta
+  ) {
+    blockchain = Blockchain.Sol;
+  }
+
   let queryParams: any = { offset, limit, blockchain };
 
   if (sortBy) {


### PR DESCRIPTION
LIQ-912

We couldn't get orders NFT from what's sold in SOL marketplace.

So I temporarily changed the code.
In this case, no matter in devnet or mainnet.
We should use "SOL" when we fetchOrders from backend.(Not use "devnet" or "mainnet-beta") 
So I did little mapping change. So that we can get orders.