### PR TITLE
[sdk] Update configBaseUrl calling order

### DIFF
--- a/core/sdk/src/shop/base/BaseShop.ts
+++ b/core/sdk/src/shop/base/BaseShop.ts
@@ -1,5 +1,5 @@
 import { Blockchain, ListBase, Nft, OrdersEditionFilterQuery, Trade, TradeQuery } from '@liqnft/candy-shop-types';
-import { configBaseUrl } from '../../vendor';
+import { configBaseUrl, getBaseUrl } from '../../vendor';
 import { CandyShopVersion, ExplorerLinkBase, ShopSettings } from './BaseShopModel';
 
 /**
@@ -30,8 +30,7 @@ export interface BaseShopConstructorParams {
 
 export abstract class BaseShop {
   // Aggregate common params as common getters in BaseShop
-  private readonly BACKEND_STAGING_URL = 'https://ckaho.liqnft.com/api';
-  private readonly BACKEND_PROD_URL = 'https://candy-shop.liqnft.com/api';
+
   protected baseUrl: string;
   protected _shopCreatorAddress: string;
   protected _treasuryMint: string;
@@ -99,19 +98,8 @@ export abstract class BaseShop {
     this._programId = params.programId;
     this._settings = params.settings;
     this._baseUnitsPerCurrency = Math.pow(10, this._settings.currencyDecimals);
-    this.baseUrl = this.getBaseUrl(this.env);
+    this.baseUrl = getBaseUrl(this.env);
     configBaseUrl(this.baseUrl);
-  }
-
-  private getBaseUrl(env: Blockchain): string {
-    switch (env) {
-      case Blockchain.SolMainnetBeta:
-      case Blockchain.Eth:
-      case Blockchain.Polygon:
-        return this.BACKEND_PROD_URL;
-      default:
-        return this.BACKEND_STAGING_URL;
-    }
   }
 
   // Properties

--- a/core/sdk/src/shop/eth/EthCandyShop.ts
+++ b/core/sdk/src/shop/eth/EthCandyShop.ts
@@ -6,7 +6,7 @@ import { Blockchain } from '@liqnft/candy-shop-types';
 import { BaseShop, BaseShopConstructorParams } from '../base/BaseShop';
 import { CandyShopVersion, ExplorerLinkBase, ShopSettings } from '../base/BaseShopModel';
 import { EthereumSDK, SeaportHelper } from '../../factory/conveyor/eth';
-import { safeAwait, SingleTokenInfo } from '../../vendor';
+import { configBaseUrl, getBaseUrl, safeAwait, SingleTokenInfo } from '../../vendor';
 import { fetchShopsByIdentifier } from '../../CandyShopInfoAPI';
 import Decimal from 'decimal.js';
 
@@ -34,6 +34,9 @@ export class EthCandyShop extends BaseShop {
    * @returns EthCandyShop
    */
   static async initEthCandyShop(params: EthShopConstructorParams): Promise<EthCandyShop> {
+    const baseUrl = getBaseUrl(params.env);
+    configBaseUrl(baseUrl);
+
     // Fetch required details for EVM setup
     const shopDetail = await safeAwait(
       fetchShopsByIdentifier(params.shopCreatorAddress, params.treasuryMint, params.programId)

--- a/core/sdk/src/vendor/config.ts
+++ b/core/sdk/src/vendor/config.ts
@@ -1,4 +1,8 @@
+import { Blockchain } from '@liqnft/candy-shop-types';
 import axios, { AxiosRequestConfig } from 'axios';
+
+const BACKEND_STAGING_URL = 'https://ckaho.liqnft.com/api';
+const BACKEND_PROD_URL = 'https://candy-shop.liqnft.com/api';
 
 const axiosInstance = axios.create({
   headers: {
@@ -8,6 +12,17 @@ const axiosInstance = axios.create({
 
 export default axiosInstance;
 let interceptorEvents: number[] = [];
+
+export const getBaseUrl = (env: Blockchain): string => {
+  switch (env) {
+    case Blockchain.SolMainnetBeta:
+    case Blockchain.Eth:
+    case Blockchain.Polygon:
+      return BACKEND_PROD_URL;
+    default:
+      return BACKEND_STAGING_URL;
+  }
+};
 
 export const configBaseUrl = (baseUrl: string): void => {
   if (interceptorEvents.length) {


### PR DESCRIPTION
To initiate the EVM CandyShop, SDK will first need to know the backend to call to fetch the correct shop object. Therefore the call to configBaseUrl will preceed the new EthCandyShop function.

Since EthCandyShop extends BaseShop and BaseShop calls configBaseUrl as well in this constructor, there will be 2 configBaseCall calls for EthCandyShop for time being.