### PR TITLE
[chore] Set no-non-null-assertion lint rule as error

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,7 +20,7 @@
     "@typescript-eslint/ban-ts-comment": "off",
     "@typescript-eslint/ban-types": "off",
     "no-async-promise-executor": "off",
-    "@typescript-eslint/no-non-null-assertion": "off",
+    "@typescript-eslint/no-non-null-assertion": "error",
     "@typescript-eslint/explicit-module-boundary-types": "off"
   },
   "parser": "@typescript-eslint/parser",

--- a/core/sdk/src/factory/conveyor/eth/EthereumPort.ts
+++ b/core/sdk/src/factory/conveyor/eth/EthereumPort.ts
@@ -18,6 +18,7 @@ interface CreateOrderParams {
   signature: string;
 }
 
+const Logger = 'CandyShopSDK/EthereumPort';
 /**
  * Handling the Ethereum transactions by Seaport
  */
@@ -93,7 +94,11 @@ export class EthereumPort {
     for (const split of shopSplit) {
       const percentage = split.percentage;
       const splitReceiver = this.getSplitReceiver(split.receiver, offerer, shop);
-      const startAmount = this.calculatePaymentSplitAmount(consideration.value!, percentage).toString();
+      if (!consideration?.value) {
+        console.log(`${Logger}: consideration.value is invalid of paymentSplit=`, split);
+        continue;
+      }
+      const startAmount = this.calculatePaymentSplitAmount(consideration.value, percentage).toString();
       considerations.push({
         token: consideration.type === AssetType.ERC20 ? consideration.address : ethers.constants.AddressZero,
         amount: startAmount,

--- a/core/sdk/src/vendor/token/parseData.ts
+++ b/core/sdk/src/vendor/token/parseData.ts
@@ -211,7 +211,7 @@ export const parseNftUpdateAuthority = async (
     throw new CandyShopError(CandyShopErrorType.NodeRequestFailed);
   }
 
-  const metadata = parseMetadata(metadataAccount.result!.data);
+  const metadata = parseMetadata(metadataAccount.result.data);
   return new PublicKey(metadata.updateAuthority);
 };
 

--- a/core/sdk/src/vendor/utils/transactionUtils.ts
+++ b/core/sdk/src/vendor/utils/transactionUtils.ts
@@ -74,6 +74,6 @@ export async function awaitTransactionSignatureConfirmation(
   }
 
   done = true;
-  console.debug(`status ${status!.confirmationStatus}`);
+  console.debug(`status ${status?.confirmationStatus}`);
   return txid;
 }


### PR DESCRIPTION
We should avoid using `!.` to bypass the TS compile for those values
could be null | undefine.
