### PR TITLE
[sdk][cli] mintPrintWithInfo

### DIFF
--- a/core/cli/src/cli.ts
+++ b/core/cli/src/cli.ts
@@ -1,4 +1,4 @@
-import { CandyShop, CandyShopError, CandyShopErrorType } from '../../sdk/src';
+import { CandyShop, CandyShopError, CandyShopErrorType, SolShopInitParams } from '../../sdk/src';
 import { getAvailableEditionNumbers, createNewMintInstructions, CandyShopDrop } from '../../sdk/src/CandyShopDrop';
 import { getEditionVaultAccount, getAuctionHouse, getAuctionHouseAuthority } from '../../sdk/src/vendor';
 import * as anchor from '@project-serum/anchor';
@@ -47,16 +47,15 @@ programCommand('sellMany')
 
     const wallet = loadKey(keypair);
 
-    const candyShop = new CandyShop({
-      candyShopCreatorAddress: new anchor.web3.PublicKey(shopCreator),
-      treasuryMint: new anchor.web3.PublicKey(treasuryMint),
-      candyShopProgramId,
-      env,
-      settings: {
-        connectionUrl: rpcUrl
-      },
+    const params: SolShopInitParams = {
+      shopCreatorAddress: shopCreator,
+      treasuryMint: treasuryMint,
+      programId: candyShopProgramId.toString(),
+      env: env,
+      settings: { connectionUrl: rpcUrl },
       isEnterprise: isEnterprise(isEnterpriseArg)
-    });
+    };
+    const candyShop = await CandyShop.initSolCandyShop(params);
 
     const tokenMints = loadTokenAccountMints(tokenAccountMintList);
 
@@ -91,16 +90,15 @@ programCommand('cancelMany')
 
     const candyShopProgramId = version === 'v1' ? CANDY_SHOP_PROGRAM_ID : CANDY_SHOP_V2_PROGRAM_ID;
 
-    const candyShop = new CandyShop({
-      candyShopCreatorAddress: new anchor.web3.PublicKey(shopCreator),
-      treasuryMint: new anchor.web3.PublicKey(treasuryMint),
-      candyShopProgramId,
-      env,
-      settings: {
-        connectionUrl: rpcUrl
-      },
+    const params: SolShopInitParams = {
+      shopCreatorAddress: shopCreator,
+      treasuryMint: treasuryMint,
+      programId: candyShopProgramId.toString(),
+      env: env,
+      settings: { connectionUrl: rpcUrl },
       isEnterprise: isEnterprise(isEnterpriseArg)
-    });
+    };
+    const candyShop = await CandyShop.initSolCandyShop(params);
 
     const tokenMints = loadTokenAccountMints(tokenAccountMintList);
 
@@ -135,16 +133,15 @@ programCommand('sell')
 
     const candyShopProgramId = version === 'v1' ? CANDY_SHOP_PROGRAM_ID : CANDY_SHOP_V2_PROGRAM_ID;
 
-    const candyShop = new CandyShop({
-      candyShopCreatorAddress: new anchor.web3.PublicKey(shopCreator),
-      treasuryMint: new anchor.web3.PublicKey(treasuryMint),
-      candyShopProgramId,
-      env,
-      settings: {
-        connectionUrl: rpcUrl
-      },
+    const params: SolShopInitParams = {
+      shopCreatorAddress: shopCreator,
+      treasuryMint: treasuryMint,
+      programId: candyShopProgramId.toString(),
+      env: env,
+      settings: { connectionUrl: rpcUrl },
       isEnterprise: isEnterprise(isEnterpriseArg)
-    });
+    };
+    const candyShop = await CandyShop.initSolCandyShop(params);
 
     const tokenAccount = await findAssociatedTokenAddress(
       new anchor.web3.PublicKey(wallet.publicKey),
@@ -175,16 +172,15 @@ programCommand('cancel')
 
     const candyShopProgramId = version === 'v1' ? CANDY_SHOP_PROGRAM_ID : CANDY_SHOP_V2_PROGRAM_ID;
 
-    const candyShop = new CandyShop({
-      candyShopCreatorAddress: new anchor.web3.PublicKey(shopCreator),
-      treasuryMint: new anchor.web3.PublicKey(treasuryMint),
-      candyShopProgramId,
-      env,
-      settings: {
-        connectionUrl: rpcUrl
-      },
+    const params: SolShopInitParams = {
+      shopCreatorAddress: shopCreator,
+      treasuryMint: treasuryMint,
+      programId: candyShopProgramId.toString(),
+      env: env,
+      settings: { connectionUrl: rpcUrl },
       isEnterprise: isEnterprise(isEnterpriseArg)
-    });
+    };
+    const candyShop = await CandyShop.initSolCandyShop(params);
 
     const tokenAccount = await findAssociatedTokenAddress(
       new anchor.web3.PublicKey(wallet.publicKey),
@@ -228,16 +224,15 @@ programCommand('buy')
 
     const candyShopProgramId = version === 'v1' ? CANDY_SHOP_PROGRAM_ID : CANDY_SHOP_V2_PROGRAM_ID;
 
-    const candyShop = new CandyShop({
-      candyShopCreatorAddress: new anchor.web3.PublicKey(shopCreator),
-      treasuryMint: new anchor.web3.PublicKey(treasuryMint),
-      candyShopProgramId,
-      env,
-      settings: {
-        connectionUrl: rpcUrl
-      },
+    const params: SolShopInitParams = {
+      shopCreatorAddress: shopCreator,
+      treasuryMint: treasuryMint,
+      programId: candyShopProgramId.toString(),
+      env: env,
+      settings: { connectionUrl: rpcUrl },
       isEnterprise: isEnterprise(isEnterpriseArg)
-    });
+    };
+    const candyShop = await CandyShop.initSolCandyShop(params);
 
     const txHash = await candyShop.buy({
       seller: new anchor.web3.PublicKey(seller),
@@ -285,16 +280,15 @@ programCommand('createAuction')
 
     const candyShopProgramId = version === 'v1' ? CANDY_SHOP_PROGRAM_ID : CANDY_SHOP_V2_PROGRAM_ID;
 
-    const candyShop = new CandyShop({
-      candyShopCreatorAddress: new anchor.web3.PublicKey(shopCreator),
-      treasuryMint: new anchor.web3.PublicKey(treasuryMint),
-      candyShopProgramId,
-      env,
-      settings: {
-        connectionUrl: rpcUrl
-      },
+    const params: SolShopInitParams = {
+      shopCreatorAddress: shopCreator,
+      treasuryMint: treasuryMint,
+      programId: candyShopProgramId.toString(),
+      env: env,
+      settings: { connectionUrl: rpcUrl },
       isEnterprise: isEnterprise(isEnterpriseArg)
-    });
+    };
+    const candyShop = await CandyShop.initSolCandyShop(params);
 
     const tokenAccount = await findAssociatedTokenAddress(
       new anchor.web3.PublicKey(wallet.publicKey),
@@ -329,16 +323,15 @@ programCommand('cancelAuction')
 
     const candyShopProgramId = version === 'v1' ? CANDY_SHOP_PROGRAM_ID : CANDY_SHOP_V2_PROGRAM_ID;
 
-    const candyShop = new CandyShop({
-      candyShopCreatorAddress: new anchor.web3.PublicKey(shopCreator),
-      treasuryMint: new anchor.web3.PublicKey(treasuryMint),
-      candyShopProgramId,
-      env,
-      settings: {
-        connectionUrl: rpcUrl
-      },
+    const params: SolShopInitParams = {
+      shopCreatorAddress: shopCreator,
+      treasuryMint: treasuryMint,
+      programId: candyShopProgramId.toString(),
+      env: env,
+      settings: { connectionUrl: rpcUrl },
       isEnterprise: isEnterprise(isEnterpriseArg)
-    });
+    };
+    const candyShop = await CandyShop.initSolCandyShop(params);
 
     const tokenAccount = await findAssociatedTokenAddress(
       new anchor.web3.PublicKey(wallet.publicKey),
@@ -368,16 +361,15 @@ programCommand('makeBid')
 
     const candyShopProgramId = version === 'v1' ? CANDY_SHOP_PROGRAM_ID : CANDY_SHOP_V2_PROGRAM_ID;
 
-    const candyShop = new CandyShop({
-      candyShopCreatorAddress: new anchor.web3.PublicKey(shopCreator),
-      treasuryMint: new anchor.web3.PublicKey(treasuryMint),
-      candyShopProgramId,
-      env,
-      settings: {
-        connectionUrl: rpcUrl
-      },
+    const params: SolShopInitParams = {
+      shopCreatorAddress: shopCreator,
+      treasuryMint: treasuryMint,
+      programId: candyShopProgramId.toString(),
+      env: env,
+      settings: { connectionUrl: rpcUrl },
       isEnterprise: isEnterprise(isEnterpriseArg)
-    });
+    };
+    const candyShop = await CandyShop.initSolCandyShop(params);
 
     const tokenAccount = await findAssociatedTokenAddress(
       new anchor.web3.PublicKey(wallet.publicKey),
@@ -405,16 +397,15 @@ programCommand('withdrawBid')
     const wallet = loadKey(keypair);
     const candyShopProgramId = version === 'v1' ? CANDY_SHOP_PROGRAM_ID : CANDY_SHOP_V2_PROGRAM_ID;
 
-    const candyShop = new CandyShop({
-      candyShopCreatorAddress: new anchor.web3.PublicKey(shopCreator),
-      treasuryMint: new anchor.web3.PublicKey(treasuryMint),
-      candyShopProgramId,
-      env,
-      settings: {
-        connectionUrl: rpcUrl
-      },
+    const params: SolShopInitParams = {
+      shopCreatorAddress: shopCreator,
+      treasuryMint: treasuryMint,
+      programId: candyShopProgramId.toString(),
+      env: env,
+      settings: { connectionUrl: rpcUrl },
       isEnterprise: isEnterprise(isEnterpriseArg)
-    });
+    };
+    const candyShop = await CandyShop.initSolCandyShop(params);
 
     const tokenAccount = await findAssociatedTokenAddress(
       new anchor.web3.PublicKey(wallet.publicKey),
@@ -442,16 +433,15 @@ programCommand('buyNow')
 
     const candyShopProgramId = version === 'v1' ? CANDY_SHOP_PROGRAM_ID : CANDY_SHOP_V2_PROGRAM_ID;
 
-    const candyShop = new CandyShop({
-      candyShopCreatorAddress: new anchor.web3.PublicKey(shopCreator),
-      treasuryMint: new anchor.web3.PublicKey(treasuryMint),
-      candyShopProgramId,
-      env,
-      settings: {
-        connectionUrl: rpcUrl
-      },
+    const params: SolShopInitParams = {
+      shopCreatorAddress: shopCreator,
+      treasuryMint: treasuryMint,
+      programId: candyShopProgramId.toString(),
+      env: env,
+      settings: { connectionUrl: rpcUrl },
       isEnterprise: isEnterprise(isEnterpriseArg)
-    });
+    };
+    const candyShop = await CandyShop.initSolCandyShop(params);
 
     const tokenAccount = await findAssociatedTokenAddress(
       new anchor.web3.PublicKey(wallet.publicKey),
@@ -479,16 +469,15 @@ programCommand('settleAndDistribute')
 
     const candyShopProgramId = version === 'v1' ? CANDY_SHOP_PROGRAM_ID : CANDY_SHOP_V2_PROGRAM_ID;
 
-    const candyShop = new CandyShop({
-      candyShopCreatorAddress: new anchor.web3.PublicKey(shopCreator),
-      treasuryMint: new anchor.web3.PublicKey(treasuryMint),
-      candyShopProgramId,
-      env,
-      settings: {
-        connectionUrl: rpcUrl
-      },
+    const params: SolShopInitParams = {
+      shopCreatorAddress: shopCreator,
+      treasuryMint: treasuryMint,
+      programId: candyShopProgramId.toString(),
+      env: env,
+      settings: { connectionUrl: rpcUrl },
       isEnterprise: isEnterprise(isEnterpriseArg)
-    });
+    };
+    const candyShop = await CandyShop.initSolCandyShop(params);
 
     const tokenAccount = await findAssociatedTokenAddress(
       new anchor.web3.PublicKey(wallet.publicKey),
@@ -514,6 +503,7 @@ programCommand('commitEditionDropNft')
   .requiredOption('-sp, --sales-period <string>', 'Sales period, unix timestamp')
   .option('-wtm, --whitelist-mint <string>', 'whitelist mint')
   .option('-wtt, --whitelist-time <string>', 'whitelist time, unix timestamp')
+  .option('-hr, --has-redemption <string>', 'The drop have redemption')
 
   .action(async (name, cmd) => {
     const {
@@ -528,6 +518,7 @@ programCommand('commitEditionDropNft')
       salesPeriod,
       whitelistMint,
       whitelistTime,
+      hasRedemption,
       version,
       isEnterpriseArg
     } = cmd.opts();
@@ -541,16 +532,15 @@ programCommand('commitEditionDropNft')
     // default to v2
     const candyShopProgramId = CANDY_SHOP_V2_PROGRAM_ID;
 
-    const candyShop = new CandyShop({
-      candyShopCreatorAddress: new anchor.web3.PublicKey(shopCreator),
-      treasuryMint: new anchor.web3.PublicKey(treasuryMint),
-      candyShopProgramId,
-      env,
-      settings: {
-        connectionUrl: rpcUrl
-      },
+    const params: SolShopInitParams = {
+      shopCreatorAddress: shopCreator,
+      treasuryMint: treasuryMint,
+      programId: candyShopProgramId.toString(),
+      env: env,
+      settings: { connectionUrl: rpcUrl },
       isEnterprise: isEnterprise(isEnterpriseArg)
-    });
+    };
+    const candyShop = await CandyShop.initSolCandyShop(params);
 
     const tokenAccountInfo = await getAccount(candyShop.connection, new PublicKey(nftOwnerTokenAccount), 'finalized');
 
@@ -561,6 +551,7 @@ programCommand('commitEditionDropNft')
       price: new anchor.BN(price),
       startTime: new anchor.BN(startTime),
       salesPeriod: new anchor.BN(salesPeriod),
+      hasRedemption: hasRedemption === 'true',
       whitelistMint: whitelistMint ? new anchor.web3.PublicKey(whitelistMint) : undefined,
       whitelistTime: whitelistTime ? new anchor.BN(whitelistTime) : undefined
     });
@@ -574,12 +565,14 @@ programCommand('mintPrint')
   .requiredOption('-tm, --treasury-mint <string>', 'Candy Shop treasury mint')
   .requiredOption('-sc, --shop-creator <string>', 'Candy Shop creator address')
   .option('-wtm, --whitelist-mint <string>', 'whitelist mint')
+  .option('-info, --info <string>', 'extra info')
 
   .action(async (name, cmd) => {
     const {
       keypair,
       env,
       nftOwnerTokenAccount,
+      info,
       treasuryMint,
       whitelistMint,
       rpcUrl,
@@ -596,16 +589,15 @@ programCommand('mintPrint')
     // default to v2
     const candyShopProgramId = CANDY_SHOP_V2_PROGRAM_ID;
 
-    const candyShop = new CandyShop({
-      candyShopCreatorAddress: new anchor.web3.PublicKey(shopCreator),
-      treasuryMint: new anchor.web3.PublicKey(treasuryMint),
-      candyShopProgramId,
-      env,
-      settings: {
-        connectionUrl: rpcUrl
-      },
+    const params: SolShopInitParams = {
+      shopCreatorAddress: shopCreator,
+      treasuryMint: treasuryMint,
+      programId: candyShopProgramId.toString(),
+      env: env,
+      settings: { connectionUrl: rpcUrl },
       isEnterprise: isEnterprise(isEnterpriseArg)
-    });
+    };
+    const candyShop = await CandyShop.initSolCandyShop(params);
 
     const tokenAccountInfo = await getAccount(candyShop.connection, new PublicKey(nftOwnerTokenAccount), 'finalized');
 
@@ -613,7 +605,8 @@ programCommand('mintPrint')
       nftOwnerTokenAccount: new PublicKey(nftOwnerTokenAccount),
       masterMint: tokenAccountInfo.mint,
       whitelistMint: whitelistMint ? new PublicKey(whitelistMint) : undefined,
-      editionBuyer: wallet
+      editionBuyer: wallet,
+      info
     });
 
     console.log('txHash', txHash);
@@ -648,16 +641,15 @@ programCommand('mintAllPrint')
     // default to v2
     const candyShopProgramId = CANDY_SHOP_V2_PROGRAM_ID;
 
-    const candyShop = new CandyShop({
-      candyShopCreatorAddress: new anchor.web3.PublicKey(shopCreator),
-      treasuryMint: new anchor.web3.PublicKey(treasuryMint),
-      candyShopProgramId,
-      env,
-      settings: {
-        connectionUrl: rpcUrl
-      },
+    const params: SolShopInitParams = {
+      shopCreatorAddress: shopCreator,
+      treasuryMint: treasuryMint,
+      programId: candyShopProgramId.toString(),
+      env: env,
+      settings: { connectionUrl: rpcUrl },
       isEnterprise: isEnterprise(isEnterpriseArg)
-    });
+    };
+    const candyShop = await CandyShop.initSolCandyShop(params);
 
     const tokenAccountInfo = await getAccount(candyShop.connection, new PublicKey(nftOwnerTokenAccount), 'finalized');
 
@@ -759,16 +751,15 @@ programCommand('redeemDrop')
     // default to v2
     const candyShopProgramId = CANDY_SHOP_V2_PROGRAM_ID;
 
-    const candyShop = new CandyShop({
-      candyShopCreatorAddress: new anchor.web3.PublicKey(shopCreator),
-      treasuryMint: new anchor.web3.PublicKey(treasuryMint),
-      candyShopProgramId,
-      env,
-      settings: {
-        connectionUrl: rpcUrl
-      },
+    const params: SolShopInitParams = {
+      shopCreatorAddress: shopCreator,
+      treasuryMint: treasuryMint,
+      programId: candyShopProgramId.toString(),
+      env: env,
+      settings: { connectionUrl: rpcUrl },
       isEnterprise: isEnterprise(isEnterpriseArg)
-    });
+    };
+    const candyShop = await CandyShop.initSolCandyShop(params);
 
     const txHash = await candyShop.redeemDrop({
       nftOwner: wallet,

--- a/core/sdk/src/factory/constants.ts
+++ b/core/sdk/src/factory/constants.ts
@@ -32,6 +32,7 @@ export const ORDER = 'order';
 export type Side = 'sell' | 'buy';
 
 export const EDITION_DROP = 'drop';
+export const RECEIPT = 'receipt';
 
 export const EDITION_MARKER_BIT_SIZE = 248;
 

--- a/core/sdk/src/factory/conveyor/sol/types/shop.type.ts
+++ b/core/sdk/src/factory/conveyor/sol/types/shop.type.ts
@@ -119,6 +119,7 @@ export interface CommitNftParams extends EditionDropParams {
   price: BN;
   startTime: BN;
   salesPeriod: BN;
+  hasRedemption: boolean;
   whitelistTime?: BN;
   candyShopProgram: Program<Idl>;
 }
@@ -130,6 +131,11 @@ export interface MintPrintParams extends EditionDropParams {
   auctionHouse: web3.PublicKey;
   editionNumber: BN;
   treasuryMint: web3.PublicKey;
+}
+
+export interface MintPrintWithInfoParams extends MintPrintParams {
+  mintReceipt: web3.PublicKey;
+  info: string;
 }
 
 export interface RedeemNftParams extends EditionDropParams {

--- a/core/sdk/src/factory/conveyor/sol/v2/editionDrop/commitNft.ts
+++ b/core/sdk/src/factory/conveyor/sol/v2/editionDrop/commitNft.ts
@@ -19,6 +19,7 @@ export const commitNft = async (params: CommitNftParams) => {
     price,
     startTime,
     salesPeriod,
+    hasRedemption,
     whitelistTime,
     program,
     candyShopProgram,
@@ -53,7 +54,7 @@ export const commitNft = async (params: CommitNftParams) => {
   const transaction = new Transaction();
 
   const ix = await program.methods
-    .shopCommitNft(price, startTime, salesPeriod, whitelistTime ? whitelistTime : null)
+    .shopCommitNft(price, startTime, salesPeriod, whitelistTime ? whitelistTime : null, hasRedemption)
     .accounts({
       commitNftCtx: {
         masterEditionTokenAccountAuthority: nftOwner.publicKey,

--- a/core/sdk/src/factory/conveyor/sol/v2/editionDrop/mintPrintWithInfo.ts
+++ b/core/sdk/src/factory/conveyor/sol/v2/editionDrop/mintPrintWithInfo.ts
@@ -1,0 +1,132 @@
+import { AccountMeta, SystemProgram, SYSVAR_RENT_PUBKEY, Transaction, TransactionInstruction } from '@solana/web3.js';
+import { getAssociatedTokenAddress, TOKEN_PROGRAM_ID } from '@solana/spl-token';
+import { MintPrintWithInfoParams } from '../../types/shop.type';
+import {
+  getAtaForMint,
+  getAuctionHouseTreasuryAcct,
+  getMetadataAccount,
+  getMasterEditionAccount,
+  getEditionMarkAccount,
+  checkEditionMintPeriod,
+  sendTx,
+  parseNftUpdateAuthority
+} from '../../../../../vendor';
+import { TOKEN_METADATA_PROGRAM_ID, WRAPPED_SOL_MINT } from '../../../../constants';
+
+export const mintPrintWithInfo = async (
+  newTokenInstruction: TransactionInstruction[],
+  params: MintPrintWithInfoParams
+) => {
+  const {
+    editionBuyer,
+    candyShop,
+    vaultAccount,
+    auctionHouse,
+    nftOwnerTokenAccount,
+    masterMint,
+    newEditionTokenAccount,
+    newEditionMint,
+    editionNumber,
+    info,
+    mintReceipt,
+    program,
+    whitelistMint,
+    treasuryMint
+  } = params;
+
+  await checkEditionMintPeriod(vaultAccount, program);
+
+  const remainingAccounts: AccountMeta[] = [];
+
+  if (!treasuryMint.equals(WRAPPED_SOL_MINT)) {
+    const buyerSplTokenAccount = await getAssociatedTokenAddress(treasuryMint, editionBuyer.publicKey, true);
+
+    remainingAccounts.push({
+      pubkey: buyerSplTokenAccount,
+      isWritable: true,
+      isSigner: false
+    });
+  }
+
+  if (whitelistMint) {
+    const [userWlTokenAccount, vaultWlTokenAccount] = await Promise.all([
+      getAssociatedTokenAddress(whitelistMint, editionBuyer.publicKey, true),
+      getAssociatedTokenAddress(whitelistMint, vaultAccount, true)
+    ]);
+
+    remainingAccounts.push({
+      pubkey: whitelistMint,
+      isWritable: true,
+      isSigner: false
+    });
+
+    remainingAccounts.push({
+      pubkey: userWlTokenAccount,
+      isWritable: true,
+      isSigner: false
+    });
+
+    remainingAccounts.push({
+      pubkey: vaultWlTokenAccount,
+      isWritable: true,
+      isSigner: false
+    });
+  }
+
+  const [
+    [vaultTokenAccount],
+    [shopTreasuryAddress],
+    [masterEditionMetadata],
+    [masterEdition],
+    [newEditionMetadata],
+    [newEdition],
+    [newEditionMark]
+  ] = await Promise.all([
+    getAtaForMint(masterMint, vaultAccount),
+    getAuctionHouseTreasuryAcct(auctionHouse),
+    getMetadataAccount(masterMint),
+    getMasterEditionAccount(masterMint),
+    getMetadataAccount(newEditionMint.publicKey),
+    getMasterEditionAccount(newEditionMint.publicKey),
+    getEditionMarkAccount(masterMint, editionNumber.toNumber())
+  ]);
+
+  const updateAuthority = await parseNftUpdateAuthority(masterEditionMetadata, program.provider.connection);
+
+  const transaction = new Transaction();
+
+  transaction.add(...newTokenInstruction);
+
+  const ix = await program.methods
+    .shopMintPrintWithInfo(editionNumber, info)
+    .accounts({
+      mintPrintCtx: {
+        newEditionBuyer: editionBuyer.publicKey,
+        vaultAccount,
+        vaultTokenAccount,
+        masterEditionMetadata,
+        masterEditionUpdateAuthority: updateAuthority,
+        masterEditionAccount: masterEdition,
+        masterEditionMint: masterMint,
+        masterEditionTokenAccount: nftOwnerTokenAccount,
+        newEditionMetadata,
+        newEditionAccount: newEdition,
+        newEditionMarker: newEditionMark,
+        newEditionMint: newEditionMint.publicKey,
+        newEditionTokenAccount,
+        shopTreasuryAddress,
+        tokenMetadataProgram: TOKEN_METADATA_PROGRAM_ID,
+        systemProgram: SystemProgram.programId,
+        tokenProgram: TOKEN_PROGRAM_ID,
+        rent: SYSVAR_RENT_PUBKEY
+      },
+      candyShop,
+      mintReceipt
+    })
+    .remainingAccounts(remainingAccounts)
+    .instruction();
+
+  transaction.add(ix);
+
+  return await sendTx(editionBuyer, transaction, program, [newEditionMint]);
+};

--- a/core/sdk/src/idl/edition_drop.json
+++ b/core/sdk/src/idl/edition_drop.json
@@ -89,6 +89,10 @@
           "type": {
             "option": "i64"
           }
+        },
+        {
+          "name": "hasRedemption",
+          "type": "bool"
         }
       ]
     },
@@ -179,6 +183,126 @@
           "type": {
             "option": "i64"
           }
+        }
+      ]
+    },
+    {
+      "name": "shopMintPrintWithInfo",
+      "accounts": [
+        {
+          "name": "mintPrintCtx",
+          "accounts": [
+            {
+              "name": "newEditionBuyer",
+              "isMut": true,
+              "isSigner": true
+            },
+            {
+              "name": "vaultAccount",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "vaultTokenAccount",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "masterEditionMetadata",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "masterEditionUpdateAuthority",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "masterEditionAccount",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "masterEditionMint",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "masterEditionTokenAccount",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "newEditionMetadata",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "newEditionAccount",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "newEditionMarker",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "newEditionMint",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "newEditionTokenAccount",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "shopTreasuryAddress",
+              "isMut": true,
+              "isSigner": false
+            },
+            {
+              "name": "tokenMetadataProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "systemProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "tokenProgram",
+              "isMut": false,
+              "isSigner": false
+            },
+            {
+              "name": "rent",
+              "isMut": false,
+              "isSigner": false
+            }
+          ]
+        },
+        {
+          "name": "candyShop",
+          "isMut": false,
+          "isSigner": false
+        },
+        {
+          "name": "mintReceipt",
+          "isMut": true,
+          "isSigner": false
+        }
+      ],
+      "args": [
+        {
+          "name": "edition",
+          "type": "u64"
+        },
+        {
+          "name": "info",
+          "type": "string"
         }
       ]
     },
@@ -504,6 +628,26 @@
           }
         ]
       }
+    },
+    {
+      "name": "MintReceipt",
+      "type": {
+        "kind": "struct",
+        "fields": [
+          {
+            "name": "mint",
+            "type": "publicKey"
+          },
+          {
+            "name": "minter",
+            "type": "publicKey"
+          },
+          {
+            "name": "info",
+            "type": "string"
+          }
+        ]
+      }
     }
   ],
   "types": [
@@ -713,6 +857,16 @@
       "code": 6032,
       "name": "InvalidUpdateAuthority",
       "msg": "invalid update authority"
+    },
+    {
+      "code": 6033,
+      "name": "InvalidFreezeAuthority",
+      "msg": "invalid freeze authority"
+    },
+    {
+      "code": 6034,
+      "name": "VaultHasNoRedemption",
+      "msg": "vault has no redemption"
     }
   ],
   "metadata": {

--- a/core/sdk/src/shop/sol/CandyShop.ts
+++ b/core/sdk/src/shop/sol/CandyShop.ts
@@ -664,8 +664,17 @@ export class CandyShop extends BaseShop implements CandyShopAuctioneer, CandySho
    * @param {CandyShopCommitNftParams} params required parameters for commit nft action
    */
   public async commitMasterNft(params: CandyShopCommitNftParams) {
-    const { nftOwnerTokenAccount, masterMint, whitelistMint, nftOwner, price, startTime, salesPeriod, whitelistTime } =
-      params;
+    const {
+      nftOwnerTokenAccount,
+      masterMint,
+      whitelistMint,
+      nftOwner,
+      price,
+      startTime,
+      salesPeriod,
+      hasRedemption,
+      whitelistTime
+    } = params;
 
     if (this._version !== CandyShopVersion.V2) {
       throw new CandyShopError(CandyShopErrorType.IncorrectProgramId);
@@ -684,6 +693,7 @@ export class CandyShop extends BaseShop implements CandyShopAuctioneer, CandySho
       price,
       startTime,
       salesPeriod,
+      hasRedemption,
       whitelistTime,
       isEnterprise: this._isEnterprise,
       connection: this.connection,
@@ -699,7 +709,7 @@ export class CandyShop extends BaseShop implements CandyShopAuctioneer, CandySho
    * @param {CandyShopMintPrintParams} params required parameters for mint print action
    */
   public async mintNewPrint(params: CandyShopMintPrintParams) {
-    const { nftOwnerTokenAccount, masterMint, whitelistMint, editionBuyer, mintEditionNumber } = params;
+    const { nftOwnerTokenAccount, masterMint, whitelistMint, editionBuyer, mintEditionNumber, info } = params;
 
     if (this._version !== CandyShopVersion.V2) {
       throw new CandyShopError(CandyShopErrorType.IncorrectProgramId);
@@ -740,6 +750,7 @@ export class CandyShop extends BaseShop implements CandyShopAuctioneer, CandySho
       candyShopProgram: this.getStaticProgram(editionBuyer),
       treasuryMint,
       mintEditionNumber,
+      info,
       instructions,
       newEditionMint,
       newEditionTokenAccount

--- a/core/sdk/src/shop/sol/CandyShopModel.ts
+++ b/core/sdk/src/shop/sol/CandyShopModel.ts
@@ -191,12 +191,14 @@ export interface CandyShopCommitNftParams extends CandyShopEditionDropParams {
   price: BN;
   startTime: BN;
   salesPeriod: BN;
+  hasRedemption: boolean;
   whitelistTime?: BN;
 }
 
 export interface CandyShopMintPrintParams extends CandyShopEditionDropParams {
   editionBuyer: AnchorWallet | web3.Keypair;
   mintEditionNumber?: string;
+  info?: string;
 }
 
 export interface CandyShopRedeemParams extends CandyShopEditionDropParams {

--- a/core/sdk/src/vendor/utils/programUtils.ts
+++ b/core/sdk/src/vendor/utils/programUtils.ts
@@ -19,6 +19,7 @@ import {
   EDITION_DROP_PROGRAM_ID,
   EDITION_MARKER_BIT_SIZE,
   FEE_PAYER,
+  RECEIPT,
   TOKEN_METADATA_PROGRAM_ID,
   TREASURY,
   WALLET,
@@ -436,4 +437,11 @@ export const getRemainingAccountsForExecuteSaleIx = async (
       ).flat();
 
   return remainingAccounts;
+};
+
+export const getMintReceipt = (vaultAccount: web3.PublicKey, editionMint: web3.PublicKey) => {
+  return web3.PublicKey.findProgramAddress(
+    [vaultAccount.toBuffer(), Buffer.from(RECEIPT), editionMint.toBuffer()],
+    EDITION_DROP_PROGRAM_ID
+  );
 };

--- a/core/ui/src/components/Drop/Confirm/index.tsx
+++ b/core/ui/src/components/Drop/Confirm/index.tsx
@@ -67,7 +67,8 @@ export const CreateEditionDropConfirm: React.FC<CreateEditionDropProps> = ({
         startTime,
         whitelistTime,
         salesPeriod: new BN(Number(formData.salesPeriod) * 60),
-        whitelistMint: formData.whitelistRelease ? new web3.PublicKey(formData.whitelistAddress) : undefined
+        whitelistMint: formData.whitelistRelease ? new web3.PublicKey(formData.whitelistAddress) : undefined,
+        hasRedemption: formData.hasRedemption
       })
       .then(() => {
         notification('Edition Drop created.\nRemember to edit and update the description.', NotificationType.Success);

--- a/core/ui/src/components/Drop/Form/index.tsx
+++ b/core/ui/src/components/Drop/Form/index.tsx
@@ -26,7 +26,8 @@ interface CreateEditionFormProps {
 enum CheckEnum {
   release = 'whitelistRelease',
   whitelistTimeFormat = 'whitelistTimeFormat',
-  launchTimeFormat = 'launchTimeFormat'
+  launchTimeFormat = 'launchTimeFormat',
+  hasRedemption = 'hasRedemption'
 }
 
 export type FormType = {
@@ -44,6 +45,7 @@ export type FormType = {
   mintPrice: string;
   whitelistRelease: boolean;
   salesPeriod: string;
+  hasRedemption: boolean;
 };
 
 const validateInput = (nodeId: keyof FormType, message: string) => {
@@ -81,7 +83,8 @@ export const CreateEditionForm: React.FC<CreateEditionFormProps> = ({
       totalSupply: nft.maxSupply,
       mintPrice: '',
       whitelistRelease: false,
-      salesPeriod: ''
+      salesPeriod: '',
+      hasRedemption: false
     };
   });
 
@@ -431,6 +434,13 @@ export const CreateEditionForm: React.FC<CreateEditionFormProps> = ({
           />
         </div>
       </div>
+
+      <Checkbox
+        onClick={onCheckbox(CheckEnum.hasRedemption)}
+        checked={Boolean(form[CheckEnum.hasRedemption])}
+        id="hasRedemption"
+        label={<span className="candy-edition-checkbox-label">Redemption enabled</span>}
+      />
 
       <div className="candy-edition-buttons">
         <button className="candy-button candy-button-default" onClick={onBack}>


### PR DESCRIPTION
### Context

Adding a `hasRedemption` option into the commitNft operation, and `info` field to the mintPrint operation.
`hasRedemption` will be used to indicate whether a vault should have the ability to link its edition NFTs to some IRL product or services, and the `info` field is used as hashed userInput for redemption validation purposes.

Note:
The shopCommitNft operation will be non-backward compatible with the newly added `hasRedemption` field.

LIQ-1055