### PR TITLE
[ui] add edition drop unlimited sales period and auction endtime when create

### DIFF
--- a/core/ui/src/components/Drop/Form/index.tsx
+++ b/core/ui/src/components/Drop/Form/index.tsx
@@ -26,7 +26,8 @@ interface CreateEditionFormProps {
 enum CheckEnum {
   release = 'whitelistRelease',
   whitelistTimeFormat = 'whitelistTimeFormat',
-  launchTimeFormat = 'launchTimeFormat'
+  launchTimeFormat = 'launchTimeFormat',
+  salesPeriodZero = 'salesPeriodZero'
 }
 
 export type FormType = {
@@ -44,6 +45,7 @@ export type FormType = {
   mintPrice: string;
   whitelistRelease: boolean;
   salesPeriod: string;
+  salesPeriodZero: boolean;
 };
 
 const validateInput = (nodeId: keyof FormType, message: string) => {
@@ -81,7 +83,8 @@ export const CreateEditionForm: React.FC<CreateEditionFormProps> = ({
       totalSupply: nft.maxSupply,
       mintPrice: '',
       whitelistRelease: false,
-      salesPeriod: ''
+      salesPeriod: '',
+      salesPeriodZero: false
     };
   });
 
@@ -99,7 +102,11 @@ export const CreateEditionForm: React.FC<CreateEditionFormProps> = ({
   const onCheckbox = (key: CheckEnum) => (e: any) => {
     e.preventDefault();
     onResetValidation();
-    setForm((prev: FormType) => ({ ...prev, [key]: !prev[key] }));
+    if (key === CheckEnum.salesPeriodZero) {
+      setForm((prev: FormType) => ({ ...prev, [key]: !prev[key], salesPeriod: '0' }));
+    } else {
+      setForm((prev: FormType) => ({ ...prev, [key]: !prev[key] }));
+    }
   };
 
   const onChangeInput = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -269,13 +276,28 @@ export const CreateEditionForm: React.FC<CreateEditionFormProps> = ({
           type="number"
           onWheel={preventUpdateNumberOnWheel}
           placeholder="0"
-          min={1}
+          min={0}
           required
           value={form['salesPeriod']}
           onChange={onChangeInput}
           step="1"
+          disabled={form.salesPeriodZero}
         />
       </div>
+
+      <Checkbox
+        onClick={onCheckbox(CheckEnum.salesPeriodZero)}
+        checked={Boolean(form[CheckEnum.salesPeriodZero])}
+        id="salesPeriodZero"
+        label={
+          <span className="candy-edition-checkbox-label">
+            Until sold out
+            <Tooltip inner="Sales will run until sold out.">
+              <span className="candy-icon-question" />
+            </Tooltip>
+          </span>
+        }
+      />
 
       <div className="candy-edition-form-price">
         <div className="candy-edition-form-item">

--- a/core/ui/src/components/Tooltip/style.less
+++ b/core/ui/src/components/Tooltip/style.less
@@ -26,7 +26,7 @@
     left: 50%;
     transform: translateX(-50%);
     padding: 6px 12px;
-    background-color: @candy-shop-popover-background;
+    background-color: #1a2029;
     transition: 0.1s all cubic-bezier(0.05, 1.09, 0.83, 0.67);
     color: #fff;
     font-weight: 400;

--- a/core/ui/src/public/Auction/CreateAuction.tsx
+++ b/core/ui/src/public/Auction/CreateAuction.tsx
@@ -104,6 +104,7 @@ export const CreateAuction: React.FC<CreateAuctionProps> = ({
       //prettier-ignore
       dayjs(auctionForm.startNow ? undefined : `${auctionForm.startDate} ${convertTime12to24(auctionForm.auctionHour, auctionForm.auctionMinute, auctionForm.clockFormat)} UTC`).unix()
     );
+    // measured in hours
     const biddingPeriod = new BN(Number(auctionForm.biddingPeriod) * 3600);
     const buyNowPrice = auctionForm.buyNow
       ? new BN(Number(auctionForm.buyNowPrice) * 10 ** candyShop.currencyDecimals)


### PR DESCRIPTION
LIQ-1173 LIQ-1179

1. [feat] edition drop can pass salesPeriod = 0 when create.
2. [feat] auction can set endtime when create.
3. [fix] change back @candy-shop-popover-background color to #fff, and set ToolTip background-color to #1a2029.
if not, the popover background color will be wrong.
![image](https://user-images.githubusercontent.com/8110233/210517618-5a47a675-13c8-4505-9c5d-ed7dfa565133.png)


[LIQ-1173]: https://liqnft.atlassian.net/browse/LIQ-1173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIQ-1179]: https://liqnft.atlassian.net/browse/LIQ-1179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ